### PR TITLE
Improve performance of JmxScraper

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -212,13 +212,15 @@ class JmxScraper {
             return;
         }
 
+        final String mBeanNameString = mBeanName.toString();
+
         for (Object object : attributes) {
             // The contents of an AttributeList should all be Attribute instances, but we'll verify
             // that.
             if (object instanceof Attribute) {
                 Attribute attribute = (Attribute) object;
                 String attributeName = attribute.getName();
-                if (mBeanName.toString().equals("java.lang:type=Runtime")
+                if (mBeanNameString.equals("java.lang:type=Runtime")
                         && (attributeName.equalsIgnoreCase("SystemProperties")
                                 || attributeName.equalsIgnoreCase("ClassPath")
                                 || attributeName.equalsIgnoreCase("BootClassPath")
@@ -226,7 +228,7 @@ class JmxScraper {
                     // Skip this attributes for the "java.lang:type=Runtime" MBean because
                     // getting the values is expensive and the values are ultimately ignored
                     continue;
-                } else if (mBeanName.toString().equals("jdk.management.jfr:type=FlightRecorder")) {
+                } else if (mBeanNameString.equals("jdk.management.jfr:type=FlightRecorder")) {
                     // Skip the FlightRecorderMXBean
                     continue;
                 }


### PR DESCRIPTION
`JmxScraper#scrapeBean()` uses `ObjectName#toString()` twice per-MBean
_attribute_ to check the MBean name against several special-cases.

`ObjectName#toString()` is quite expensive, because it allocates a new
`char[]` and copies the name data into it, on each call.

Consequently, when there are a large number of number of MBean attributes,
these calls compound and can create performance problems.

Caching the result of `ObjectName#toString()` outside this loop ensures
we only call it once per-MBean.
